### PR TITLE
Add jade and logo

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,5 @@
 var pkgs = require("pkgs")
-var names = "browserify grunt-cli bower gulp grunt express npm cordova forever less pm2 karma coffee-script statsd yo karma-phantomjs-launcher phonegap mocha jshint ronn express-generator statsd-librato-backend eslint istanbul protractor".split(" ")
+var names = "jade browserify grunt-cli bower gulp grunt express npm cordova forever less pm2 karma coffee-script statsd yo karma-phantomjs-launcher phonegap mocha jshint ronn express-generator statsd-librato-backend eslint istanbul protractor".split(" ")
 var opts = {
   omit: ["readme"]
 }

--- a/logos.js
+++ b/logos.js
@@ -9,7 +9,7 @@ module.exports = {
   gulp: "https://raw.githubusercontent.com/gulpjs/artwork/master/gulp-2x.png",
   grunt: "https://i.cloudup.com/bDkmXyEmr5.png",
   "grunt-cli": "https://i.cloudup.com/bDkmXyEmr5.png",
-  jade: "http://garthdb.com/img/jade_branding/jade-01.svg",
+  jade: "https://cldup.com/5q08DaEBdw.png",
   karma: "https://cldup.com/0286W-2y27.png",
   less: "https://i.cloudup.com/LYSQDzsBKK.png",
   npm: "https://cldup.com/Rg6WLgqccB.svg",

--- a/logos.js
+++ b/logos.js
@@ -9,6 +9,7 @@ module.exports = {
   gulp: "https://raw.githubusercontent.com/gulpjs/artwork/master/gulp-2x.png",
   grunt: "https://i.cloudup.com/bDkmXyEmr5.png",
   "grunt-cli": "https://i.cloudup.com/bDkmXyEmr5.png",
+  jade: "http://garthdb.com/img/jade_branding/jade-01.svg",
   karma: "https://cldup.com/0286W-2y27.png",
   less: "https://i.cloudup.com/LYSQDzsBKK.png",
   npm: "https://cldup.com/Rg6WLgqccB.svg",


### PR DESCRIPTION
[closes npm/newww#1374]

It looks like this is where the list of "packages people 'npm install' a lot" comes from on the npm website.  Jade has a higher number of monthly downloads than most of those packages, so I was wondering why it didn't appear on this list.  Is there something I've missed or should it be added?
