### PR TITLE
add support for proxy/non-standard registry URL

### DIFF
--- a/bin/npm-explicit-installs.js
+++ b/bin/npm-explicit-installs.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+var npmExplicitInstalls = require('../')
+var chalk = require('chalk')
+
+require('yargs')
+  .usage('$0 <cmd> [options]')
+  .command('dry-run', 'show the packages that would be displayed on the home page', function () {
+    npmExplicitInstalls(function (err, pkgs) {
+      pkgs.forEach(function (pkg) {
+        console.log(chalk.green(pkg.name), '(' + pkg.version + ')', chalk.gray(pkg.publisher.name))
+      })
+      npmExplicitInstalls.client.end()
+    })
+  })
+  .command('delete', 'delete packages from the home page', function () {
+  })
+  .demand(1)
+  .argv

--- a/bin/npm-explicit-installs.js
+++ b/bin/npm-explicit-installs.js
@@ -6,8 +6,13 @@ var chalk = require('chalk')
 require('yargs')
   .usage('$0 <cmd> [options]')
   .command('dry-run', 'show the packages that would be displayed on the home page', function () {
-    npmExplicitInstalls.client.on("connect", function () {
+    npmExplicitInstalls.client.on('connect', function () {
       npmExplicitInstalls(function (err, pkgs) {
+        if (err) {
+          console.log(chalk.red(err.message))
+          return
+        }
+
         pkgs.forEach(function (pkg) {
           console.log(chalk.green(pkg.name), '(' + pkg.version + ')', chalk.gray(pkg.publisher.name))
         })
@@ -17,5 +22,7 @@ require('yargs')
   })
   .command('delete', 'delete packages from the home page', function () {
   })
-  .demand(1)
+  .help('help')
+  .alias('h', 'help')
+  .demand(1, 'you must provide a command to run')
   .argv

--- a/bin/npm-explicit-installs.js
+++ b/bin/npm-explicit-installs.js
@@ -6,11 +6,13 @@ var chalk = require('chalk')
 require('yargs')
   .usage('$0 <cmd> [options]')
   .command('dry-run', 'show the packages that would be displayed on the home page', function () {
-    npmExplicitInstalls(function (err, pkgs) {
-      pkgs.forEach(function (pkg) {
-        console.log(chalk.green(pkg.name), '(' + pkg.version + ')', chalk.gray(pkg.publisher.name))
+    npmExplicitInstalls.client.on("connect", function () {
+      npmExplicitInstalls(function (err, pkgs) {
+        pkgs.forEach(function (pkg) {
+          console.log(chalk.green(pkg.name), '(' + pkg.version + ')', chalk.gray(pkg.publisher.name))
+        })
+        npmExplicitInstalls.client.end()
       })
-      npmExplicitInstalls.client.end()
     })
   })
   .command('delete', 'delete packages from the home page', function () {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "./bin/npm-explicit-installs.js",
   "scripts": {
-    "//pretest": "standard",
+    "pretest": "standard",
     "test": "nyc mocha ./test/*.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "3.0.0",
   "description": "A temporary thing to get stuff on the npm homepage",
   "main": "index.js",
+  "bin": "./bin/npm-explicit-installs.js",
   "scripts": {
-    "pretest": "standard",
+    "//pretest": "standard",
     "test": "nyc mocha ./test/*.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
@@ -22,9 +23,13 @@
   },
   "homepage": "https://github.com/npm/npm-explicit-installs",
   "dependencies": {
+    "async": "^1.5.2",
     "bluebird": "^3.1.5",
-    "pkgs": "^1.2.0",
-    "redis": "^2.4.2"
+    "chalk": "^1.1.1",
+    "inquirer": "^0.11.4",
+    "npm-stats": "^1.2.0",
+    "redis": "^2.4.2",
+    "yargs": "^3.32.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
This pull adds:
- support for `PROXY_URL` so that companies with strict firewalls can still load package meta information.
- support for `COUCH_URL_REMOTE`, so that packages can be loaded from a non-standard registry.
