### PR TITLE
load packages dynamically, be smart about busting cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bluebird": "^3.1.5",
     "chalk": "^1.1.1",
     "inquirer": "^0.11.4",
+    "lodash.xor": "^4.0.1",
     "npm-stats": "^1.2.0",
     "redis": "^2.4.2",
     "yargs": "^3.32.0"


### PR DESCRIPTION
I didn't want to have to direct folks to restart their npm On-Site instance to load new front-page modules. 

Worse still, I didn't want to direct people to clear their Redis cache! this would have been horrible!

This pull now:
- invalidates the cache automatically if the packages on disk have changed.
- loads packages dynamically -- so that no restart will be needed if the packages are updated on the front-page.
