### PR TITLE
there's now a slick (if command-line based) UI for editing the home page packages

### DIFF
--- a/bin/npm-explicit-installs.js
+++ b/bin/npm-explicit-installs.js
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 
-var npmExplicitInstalls = require('../')
 var chalk = require('chalk')
+var fs = require('fs')
+var path = require('path')
+var inquirer = require('inquirer')
 
 require('yargs')
   .usage('$0 <cmd> [options]')
   .command('dry-run', 'show the packages that would be displayed on the home page', function () {
+    var npmExplicitInstalls = require('../')
     npmExplicitInstalls.client.on('connect', function () {
       npmExplicitInstalls(function (err, pkgs) {
         if (err) {
@@ -21,6 +24,42 @@ require('yargs')
     })
   })
   .command('delete', 'delete packages from the home page', function () {
+    var packages = require('../packages')
+    inquirer.prompt({
+      name: 'package',
+      message: 'remove package from homepage',
+      type: 'list',
+      choices: packages,
+    }, function (answer) {
+      packages.splice(packages.indexOf(answer.package), 1)
+      fs.writeFileSync(path.resolve(__dirname, '../packages.json'), JSON.stringify(packages, null, 2), 'utf-8')
+    })
+  })
+  .command('add', 'add a new package to the home page', function () {
+    var packages = require('../packages')
+    var logos = require('../logos')
+
+    inquirer.prompt([
+      {
+        name: 'package',
+        message: 'name of package to add',
+        validate: function (input) {
+          if (!input.length) return 'you must provide a package name'
+          else return true
+        }
+      },
+      {
+        name: 'logo',
+        message: 'url of icon to use for package (optional)'
+      }
+    ], function (answer) {
+      if (answer.logo) {
+        logos[answer.package] = answer.logo
+        fs.writeFileSync(path.resolve(__dirname, '../logos.json'), JSON.stringify(logos, null, 2), 'utf-8')
+      }
+      packages.push(answer.package)
+      fs.writeFileSync(path.resolve(__dirname, '../packages.json'), JSON.stringify(packages, null, 2), 'utf-8')
+    })
   })
   .help('help')
   .alias('h', 'help')

--- a/bin/npm-explicit-installs.js
+++ b/bin/npm-explicit-installs.js
@@ -29,7 +29,7 @@ require('yargs')
       name: 'package',
       message: 'remove package from homepage',
       type: 'list',
-      choices: packages,
+      choices: packages
     }, function (answer) {
       packages.splice(packages.indexOf(answer.package), 1)
       fs.writeFileSync(path.resolve(__dirname, '../packages.json'), JSON.stringify(packages, null, 2), 'utf-8')

--- a/bin/npm-explicit-installs.js
+++ b/bin/npm-explicit-installs.js
@@ -67,6 +67,19 @@ require('yargs')
       fs.writeFileSync(path.resolve(__dirname, '../packages.json'), JSON.stringify(packages, null, 2), 'utf-8')
     })
   })
+  .command('bust-cache', 'clear the cache of home page packages', function () {
+    var npmExplicitInstalls = require('../')
+    npmExplicitInstalls.client.on('connect', function () {
+      npmExplicitInstalls.bustCache(function (err) {
+        if (err) {
+          console.log(chalk.red(err.message))
+          return
+        }
+        console.log(chalk.green('cache cleared'))
+        npmExplicitInstalls.client.end()
+      })
+    })
+  })
   .help('help')
   .alias('h', 'help')
   .demand(1, 'you must provide a command to run')

--- a/bin/npm-explicit-installs.js
+++ b/bin/npm-explicit-installs.js
@@ -25,6 +25,8 @@ require('yargs')
   })
   .command('delete', 'delete packages from the home page', function () {
     var packages = require('../packages')
+    var logos = require('../logos')
+
     inquirer.prompt({
       name: 'package',
       message: 'remove package from homepage',
@@ -33,6 +35,10 @@ require('yargs')
     }, function (answer) {
       packages.splice(packages.indexOf(answer.package), 1)
       fs.writeFileSync(path.resolve(__dirname, '../packages.json'), JSON.stringify(packages, null, 2), 'utf-8')
+      if (logos[answer.package]) {
+        delete logos[answer.package]
+        fs.writeFileSync(path.resolve(__dirname, '../logos.json'), JSON.stringify(logos, null, 2), 'utf-8')
+      }
     })
   })
   .command('add', 'add a new package to the home page', function () {

--- a/index.js
+++ b/index.js
@@ -122,6 +122,19 @@ function populateCache (pkgs) {
   })
 }
 
+ExplicitInstalls.bustCache = function (cb) {
+  return new Promise(function (resolve, reject) {
+    // redis client is failing to connect, don't set cache.
+    if (!ExplicitInstalls.client.connected) return reject('redis not connected')
+
+    ExplicitInstalls.client.del(ExplicitInstalls.cacheKey, function (err) {
+      if (err) console.error('failed to bust cache:', ExplicitInstalls.cacheKey)
+      return resolve()
+    })
+  })
+  .nodeify(cb)
+}
+
 /*
   Make pkgs match the format expected by newww:
     {{name}}

--- a/index.js
+++ b/index.js
@@ -91,7 +91,11 @@ function loadPackageMeta (pkgs, logos) {
   return new Promise(function (resolve, reject) {
     map(pkgs, function (pkg, cb) {
       ExplicitInstalls.npmStats(opts).module(pkg).info(function (err, info) {
-        return cb(err, info)
+        if (err) {
+          console.error('failed to load package:', err.message)
+          return cb(null, packageError(pkg))
+        }
+        return cb(null, info)
       })
     }, function (err, pkgs) {
       if (err) {
@@ -140,6 +144,26 @@ function mapPkgs (pkgs, logos) {
       logo: logos[pkg.name]
     }
   })
+}
+
+function packageError (pkg) {
+  return {
+    name: pkg,
+    description: 'not found',
+    'dist-tags': {
+      latest: 'n/a'
+    },
+    time: {
+      'n/a': Date().toString()
+    },
+    versions: {
+      'n/a': {
+        _npmUser: {
+          name: 'n/a'
+        }
+      }
+    }
+  }
 }
 
 module.exports = ExplicitInstalls

--- a/test/test.js
+++ b/test/test.js
@@ -180,11 +180,11 @@ describe('npm-explicit-installs', function () {
   })
 
   describe('package service is down', function () {
-    it('resolves an empty array of packages', function (done) {
-      mockNpmStats(npmExplicitInstalls, Error("i hame no idea what I'm doing"))
+    it('populates packages with the default packageError object', function (done) {
+      mockNpmStats(npmExplicitInstalls, Error("i have no idea what I'm doing"))
       npmExplicitInstalls(function (err, pkgs) {
         expect(err).to.equal(null)
-        expect(pkgs).to.deep.equal([])
+        pkgs[0].description.should.equal('not found')
         return done()
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,22 @@ describe('npm-explicit-installs', function () {
       })
     })
 
+    describe('bustCache', function () {
+      it('deletes entry in redis', function (done) {
+        npmExplicitInstalls.client.set(npmExplicitInstalls.cacheKey, JSON.stringify({}), function (err) {
+          expect(err).to.equal(null)
+          npmExplicitInstalls.bustCache(function (err) {
+            expect(err).to.equal(null)
+            npmExplicitInstalls.client.get(npmExplicitInstalls.cacheKey, function (err, res) {
+              expect(err).to.equal(null)
+              expect(res).to.equal(null)
+              return done()
+            })
+          })
+        })
+      })
+    })
+
     after(function () { npmExplicitInstalls.client.end() })
   })
 


### PR DESCRIPTION
There's now a UI for editing the packages on the home-page:

**deleting looks like this:**

<img width="853" alt="screen shot 2016-02-02 at 3 27 58 pm" src="https://cloud.githubusercontent.com/assets/194609/12768017/b5cbd43c-c9c1-11e5-9659-a3aa76b182fc.png">

**adding looks like this:**

<img width="397" alt="screen shot 2016-02-02 at 3 28 19 pm" src="https://cloud.githubusercontent.com/assets/194609/12768029/c4b2cc6c-c9c1-11e5-84db-882634d5c423.png">

**at the end of the day, the home page looks like this:**

<img width="1258" alt="screen shot 2016-02-02 at 3 25 01 pm" src="https://cloud.githubusercontent.com/assets/194609/12768033/ce7db1bc-c9c1-11e5-9acc-4fe0ff85e294.png">

This functionality will be exposed as an npmo admin command. It's the sort of thing that will probably rarely change once someone configures their server, so this seems like a reasonable approach to begin with.
