### PR TITLE
support for a logo field in a package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,9 +192,18 @@ function mapPkgs (pkgs, logos) {
       version: version,
       lastPublishedAt: pkg.time[version],
       publisher: pkg.versions[version]._npmUser,
-      logo: logos[pkg.name]
+      logo: getLogo(pkg.versions[version], logos)
     }
   })
+}
+
+function getLogo (latest, logos) {
+  var logo = latest.logo
+  if (typeof logo === 'string') {
+    return logo
+  } else {
+    return logos[latest.name]
+  }
 }
 
 function packageError (pkg) {

--- a/index.js
+++ b/index.js
@@ -80,6 +80,12 @@ ExplicitInstalls.client.on('error', function (err) {
   console.error('redis emitted error:', err.message)
 })
 ExplicitInstalls.cacheKey = '__npm_explicit_installs'
+ExplicitInstalls.supportedExtensions = [
+  '.gif',
+  '.png',
+  '.jpg',
+  '.jpeg'
+]
 
 var hour = 1000 * 60 * 60
 ExplicitInstalls.cacheTtl = hour * 4 // only reload packages every 4 hours.
@@ -199,7 +205,11 @@ function mapPkgs (pkgs, logos) {
 
 function getLogo (latest, logos) {
   var logo = latest.logo
-  if (typeof logo === 'string') {
+  var extension = typeof logo === 'string' ? path.parse(logo).ext : null
+  if (typeof logo === 'string' &&
+    process.env.FEATURE_NPMO &&
+    ~ExplicitInstalls.supportedExtensions.indexOf(extension)
+  ) {
     return logo
   } else {
     return logos[latest.name]

--- a/test/test.js
+++ b/test/test.js
@@ -217,20 +217,44 @@ describe('npm-explicit-installs', function () {
     })
 
     describe('logos', function () {
+      it('should not use logo from package.json, unless we are npmo', function (done) {
+        npmExplicitInstalls(function (err, pkgs) {
+          expect(err).to.equal(null)
+          // browserify has a string URL logo.
+          pkgs[0].logo.should.equal('https://d21ii91i3y6o6h.cloudfront.net/gallery_images/from_proof/1647/small/1405586570/browserify-2-hexagon-sticker.png')
+          return done()
+        })
+      })
+
+      it('should not use logo from package.json, if it is not a supported image type', function (done) {
+        process.env.FEATURE_NPMO = 'true'
+        npmExplicitInstalls(function (err, pkgs) {
+          expect(err).to.equal(null)
+          // gulp has an svg image which we do not currently support.
+          pkgs[3].logo.should.equal('https://raw.githubusercontent.com/gulpjs/artwork/master/gulp-2x.png')
+          delete process.env.FEATURE_NPMO
+          return done()
+        })
+      })
+
       it('should use the logo from a package.json if it exists and is a string', function (done) {
+        process.env.FEATURE_NPMO = 'true'
         npmExplicitInstalls(function (err, pkgs) {
           expect(err).to.equal(null)
           // browserify has a string URL logo.
           pkgs[0].logo.should.equal('http://example.com/logo.png')
+          delete process.env.FEATURE_NPMO
           return done()
         })
       })
 
       it('should not use logo from package.json if it is not a string', function (done) {
+        process.env.FEATURE_NPMO = 'true'
         npmExplicitInstalls(function (err, pkgs) {
           expect(err).to.equal(null)
           // bower has an object representing its logo.
           pkgs[2].logo.should.equal('https://i.cloudup.com/Ka0R3QvWRs.png')
+          delete process.env.FEATURE_NPMO
           return done()
         })
       })

--- a/test/test.js
+++ b/test/test.js
@@ -217,7 +217,7 @@ describe('npm-explicit-installs', function () {
     })
 
     describe('logos', function () {
-      it('should use the logo from a package.json if it exists is a string', function (done) {
+      it('should use the logo from a package.json if it exists and is a string', function (done) {
         npmExplicitInstalls(function (err, pkgs) {
           expect(err).to.equal(null)
           // browserify has a string URL logo.

--- a/test/test.js
+++ b/test/test.js
@@ -216,6 +216,26 @@ describe('npm-explicit-installs', function () {
       })
     })
 
+    describe('logos', function () {
+      it('should use the logo from a package.json if it exists is a string', function (done) {
+        npmExplicitInstalls(function (err, pkgs) {
+          expect(err).to.equal(null)
+          // browserify has a string URL logo.
+          pkgs[0].logo.should.equal('http://example.com/logo.png')
+          return done()
+        })
+      })
+
+      it('should not use logo from package.json if it is not a string', function (done) {
+        npmExplicitInstalls(function (err, pkgs) {
+          expect(err).to.equal(null)
+          // bower has an object representing its logo.
+          pkgs[2].logo.should.equal('https://i.cloudup.com/Ka0R3QvWRs.png')
+          return done()
+        })
+      })
+    })
+
     after(function () { npmExplicitInstalls.client.end() })
   })
 


### PR DESCRIPTION
we'll now look for a logo field in package.json and use it if it's a string:

<img width="1048" alt="screen shot 2016-02-03 at 3 05 36 pm" src="https://cloud.githubusercontent.com/assets/194609/12832251/ae7a7430-cb4d-11e5-8299-33b16c7d0052.png">

CC: @jefflembeck
