### PR TITLE
allow modules from private registry to be displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "chalk": "^1.1.1",
     "inquirer": "^0.11.4",
     "lodash.xor": "^4.0.1",
-    "npm-stats": "^1.2.0",
     "redis": "^2.4.2",
+    "request": "^2.69.0",
     "yargs": "^3.32.0"
   },
   "devDependencies": {


### PR DESCRIPTION
When I deployed this, we immediately had a feature request asking for the ability to list private modules from npmo on the homepage. This definitely seems like something we should support!

Here's how I've approached this:
- if we see a module prefixed with `@`, we assume it's from their private npm On-Site registry:
  - we route the request to `FRONT_DOOR_HOST`, with `SHARED_FETCH_SECRET` for auth.
  - we ignore the `PROXY_URL` setting (since npm On-Site is on internal networking).
- if the module does not have a `@`, we assume it's a global package:
  - we route the request to `COUCH_URL_REMOTE`.
  - we respect the `PROXY_URL` setting, since the request is going to the outside world.
