### PR TITLE
fix: make redis stop spitting out a warning message

### DIFF
--- a/bin/npm-explicit-installs.js
+++ b/bin/npm-explicit-installs.js
@@ -19,7 +19,7 @@ require('yargs')
         pkgs.forEach(function (pkg) {
           console.log(chalk.green(pkg.name), '(' + pkg.version + ')', chalk.gray(pkg.publisher.name))
         })
-        npmExplicitInstalls.client.end()
+        npmExplicitInstalls.client.end(true)
       })
     })
   })
@@ -76,7 +76,7 @@ require('yargs')
           return
         }
         console.log(chalk.green('cache cleared'))
-        npmExplicitInstalls.client.end()
+        npmExplicitInstalls.client.end(true)
       })
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -71,7 +71,7 @@ describe('npm-explicit-installs', function () {
       })
     })
 
-    after(function () { npmExplicitInstalls.client.end() })
+    after(function () { npmExplicitInstalls.client.end(true) })
   })
 
   describe('redis is up', function () {
@@ -182,7 +182,7 @@ describe('npm-explicit-installs', function () {
       var original = npmExplicitInstalls.client
       npmExplicitInstalls.client = client
 
-      client.end()
+      client.end(true)
       npmExplicitInstalls(function (err, pkgs) {
         npmExplicitInstalls.client = original
         expect(err).to.equal(null)
@@ -254,7 +254,7 @@ describe('npm-explicit-installs', function () {
       })
     })
 
-    after(function () { npmExplicitInstalls.client.end() })
+    after(function () { npmExplicitInstalls.client.end(true) })
   })
 
   describe('package service is down', function () {


### PR DESCRIPTION
flush must now explicitly be set to `true`.
