### PR TITLE
fix: redis ttl should be in seconds not milliseconds fixes #19

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ ExplicitInstalls.supportedExtensions = [
   '.jpeg'
 ]
 
-var hour = 1000 * 60 * 60
+var hour = 60 * 60
 ExplicitInstalls.cacheTtl = hour * 4 // only reload packages every 4 hours.
 
 function checkCache () {


### PR DESCRIPTION
fixes #19 

we were accidentally caching for 167 days rather than 4 hours, I guess I was originally planning for the ttl to be in JavaScript.
